### PR TITLE
Bug fix: recipe view not working w/o user login

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -517,7 +517,10 @@ function populateRecipeView() {
 }
 
 function isItBookmarked(recipeToCheck) {
-  let matchedRecipe = currentUser.recipesToCook.find(recipe => recipe.id === recipeToCheck.id)
+  let matchedRecipe;
+  if (currentUser) {
+    matchedRecipe = currentUser.recipesToCook.find(recipe => recipe.id === recipeToCheck.id);
+  }
   if (matchedRecipe) {
     document.querySelector('#recipe-bookmark').classList.replace('recipe-view-bookmark-icon', 'recipe-bookmark-icon--active')
   } else {


### PR DESCRIPTION
Fixed a bug where recipe-view was trying to pull information from `currentUser` while `currentUser` was `undefined`.

Recipe view now works correctly

(Merging myself since outside of project due date)